### PR TITLE
Attaching a composer to all components

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -91,6 +91,19 @@ The array will be automatically merged with any existing composers for the compo
 
 When you call the `Inertia::render('User/Profile')` the props should now include the composed data.
 
+### Attaching a composer to all components
+
+You can also set a composer or multiple composers to all components using the * character as a wildcard, like so:
+
+```php
+Inertia::composer('*', [
+    UserComposer::class,
+    function (ResponseFactory $inertia) {
+        $inertia->with(...);
+    }
+]);
+```
+
 ## Security
 
 If you discover any security related issues, please email author email instead of using the issue tracker.

--- a/src/Kinetic.php
+++ b/src/Kinetic.php
@@ -33,6 +33,9 @@ class Kinetic extends ResponseFactory
 
         $this->resolveComposedProps($component);
 
+        // The composer method also accepts the * character as a wildcard, allowing you to attach a composer to all components
+        $this->resolveComposedProps('*');
+
         return parent::render($component, array_merge($props, $this->composedProps));
     }
 

--- a/tests/Features/KineticTest.php
+++ b/tests/Features/KineticTest.php
@@ -173,4 +173,33 @@ class KineticTest extends BaseTestCase
             ),
         ]);
     }
+
+    public function test_can_use_star_character_for_attach_composers_to_all_components(): void
+    {
+        $description = 'this compose for all components.';
+
+        Inertia::composer('*', $callback = function ($inertia) use ($description) {
+            $inertia->with(['global' => $description]);
+        });
+
+        $this->assertEquals(
+            [$callback],
+            app(ComposerBag::class)->get('*')
+        );
+
+        Route::middleware([StartSession::class])->get('/', function () {
+            return Inertia::render('User/Profile', ['user' => 'John Doe']);
+        });
+
+        $response = $this->withoutExceptionHandling()->get('/', ['X-Inertia' => 'true']);
+
+        $response->assertSuccessful();
+        $response->assertJson([
+            'component' => 'User/Profile',
+            'props' => array_merge(
+                ['global' => $description],
+                ['user' => 'John Doe'],
+            ),
+        ]);
+    }
 }


### PR DESCRIPTION
Hi,
I use your package, it's very nice for work with composers like views but i saw that it is not possible to register composers for all components, such as [view composers](https://laravel.com/docs/9.x/views#attaching-a-composer-to-multiple-views) (_The composer method also accepts the * character as a wildcard, allowing you to attach a composer to all views_).
So I tried to add this feature to your package, I hope it is useful.