### PR TITLE
Add ability to use wildcards in composer registration

### DIFF
--- a/src/ComposerBag.php
+++ b/src/ComposerBag.php
@@ -2,6 +2,7 @@
 
 namespace Ambengers\Kinetic;
 
+use Illuminate\Support\Str;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Inertia\ResponseFactory;
@@ -36,7 +37,7 @@ class ComposerBag
             // Let us merge the existing composers for the component if any
             // and then we will make sure we only set unique composers...
             $composers = Collection::make([
-                ...$this->get($component, []),
+                ...Arr::get($this->composers, $component, []),
                 ...$composers,
             ])->unique()->toArray();
 
@@ -53,7 +54,18 @@ class ComposerBag
      */
     public function get($component = null, $default = [])
     {
-        return Arr::wrap(Arr::get($this->composers, $component, $default));
+        $composers = $this->composers;
+
+        foreach ($this->composers as $vue => $composer) {
+            if (Str::contains($vue, '*') && Str::is($vue, $component)) {
+                $composers[$component] = array_merge(
+                    Arr::get($composers, $component, []),
+                    Arr::wrap($composer),
+                );
+            }
+        }
+        
+        return Arr::wrap(Arr::get($composers, $component, $default));
     }
 
     /**

--- a/tests/Features/KineticTest.php
+++ b/tests/Features/KineticTest.php
@@ -135,6 +135,21 @@ class KineticTest extends BaseTestCase
         );
     }
 
+    public function test_can_use_wildcard_composer_to_match_all_components()
+    {
+        Inertia::composer('*', UserComposer::class);
+
+        $this->assertEquals(
+            [UserComposer::class],
+            app(ComposerBag::class)->get('Foo')
+        );
+
+        $this->assertEquals(
+            [UserComposer::class],
+            app(ComposerBag::class)->get('Bar')
+        );
+    }
+
     public function test_can_use_class_based_composers_for_a_component(): void
     {
         Inertia::composer('User/Profile', UserComposer::class);

--- a/tests/Features/KineticTest.php
+++ b/tests/Features/KineticTest.php
@@ -89,6 +89,52 @@ class KineticTest extends BaseTestCase
         ], app(ComposerBag::class)->get());
     }
 
+    public function test_can_use_wildcard_composer_for_nested_components()
+    {
+        Inertia::composer('User/*', UserComposer::class);
+
+        $this->assertEquals(
+            [],
+            app(ComposerBag::class)->get('User')
+        );
+
+        $this->assertEquals(
+            [UserComposer::class],
+            app(ComposerBag::class)->get('User/Profile')
+        );
+
+        $this->assertEquals(
+            [UserComposer::class],
+            app(ComposerBag::class)->get('User/Admin/Profile')
+        );
+    }
+
+    public function test_can_use_wildcard_composer_with_named_and_closure_composers()
+    {
+        Inertia::composer('User/*', UserComposer::class);
+        Inertia::composer('User/Profile', $callback = function () {});
+
+        $this->assertEquals(
+            [$callback, UserComposer::class],
+            app(ComposerBag::class)->get('User/Profile')
+        );
+    }
+
+    public function test_can_use_nested_wildcard_composers()
+    {
+        Inertia::composer(['User/*', 'Users/*/Profile'], UserComposer::class);
+
+        $this->assertEquals(
+            [UserComposer::class],
+            app(ComposerBag::class)->get('User/Profile')
+        );
+
+        $this->assertEquals(
+            [UserComposer::class],
+            app(ComposerBag::class)->get('User/Admin/Profile')
+        );
+    }
+
     public function test_can_use_class_based_composers_for_a_component(): void
     {
         Inertia::composer('User/Profile', UserComposer::class);


### PR DESCRIPTION
Closes #4 

This PR adds the ability to use wildcards in composer registration that allows you to register one composer across many that match the asterisk pattern.

Ex:

```php
// Match any nested component in the "Reports" folder:
Inertia::composer('Reports/*', ReportComposer::class);

// Match any component:
Inertia::composer('*', AppComposer::class);
```

Please let me know if you'd like anything adjusted, thanks for your time! ❤️ 